### PR TITLE
Add dataset as property.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,7 @@ module.exports.properties = [
 ,"controls"
 ,"crossOrigin"
 ,"data"
+,"dataset"
 ,"defer"
 ,"dir"
 ,"download"


### PR DESCRIPTION
When virtualizing nodes data attributes were skipped. There is code for virtualizing them in _index.js_ starting at line 95, but this depends on `"dataset"` being present in the list of properties.

I noticed the comment `// However, I'm not sure if this is compatible with h()`, so maybe that's why it's not in the properties list. However, using `h()` to create data properties has been working fine for me using `"virtual-hyperscript": "4.4.0"`.
