### PR TITLE
Does proper falsy check on empty properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ function getElementProperties(el) {
   var obj = {}
 
   props.forEach(function(propName) {
-    if(!el[propName]) return
+    if(el[propName] === void 0 || el[propName] === null) return
+    if(propName === 'tabIndex' && el[propName] === -1) return
 
     // Special case: style
     // .style is a DOMStyleDeclaration, thus we need to iterate over all
@@ -75,7 +76,7 @@ function getElementProperties(el) {
     if("style" == propName) {
       var css = {}
         , styleProp
-      for(var i=0; i<el.style.length; i++) {
+      for(var i=0; i<el.style; i++) {
         styleProp = el.style[i]
         css[styleProp] = el.style.getPropertyValue(styleProp) // XXX: add support for "!important" via getPropertyPriority()!
       }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function getElementProperties(el) {
     if("style" == propName) {
       var css = {}
         , styleProp
-      for(var i=0; i<el.style; i++) {
+      for(var i=0; i<el.style.length; i++) {
         styleProp = el.style[i]
         css[styleProp] = el.style.getPropertyValue(styleProp) // XXX: add support for "!important" via getPropertyPriority()!
       }


### PR DESCRIPTION
for instance tabIndex is added as a property because the browser sets it to -1 which is truthy.

It might be that its best to create a ignore map.