### PR TITLE
fix set tabindex to all the node

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ function getElementProperties(el) {
     // some properties are only accessible via .attributes, so 
     // that's what we'd do, if vdom-create-element could handle this.
     if("attributes" == propName) return
+    if("tabIndex" == propName && el.tabIndex === -1) return
     
 
     // default: just copy the property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vdom-virtualize",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Virtulize any DOM node and turn it into a virtual-dom node.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
if set tabindex to all the node will cause blue highlight border around the dom if the dom created by virtualize is clicked

for example: the blue border isnt what I want
![d492c369-9e0a-447e-a93d-1a56a10cd403](https://cloud.githubusercontent.com/assets/3351878/5538475/7119e3ae-8aef-11e4-92bf-33205459a8d6.png)
