### PR TITLE
Ignore unhandled nodes (i.e., comments)

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,12 @@ function createFromElement(el) {
   , properties = getElementProperties(el)
   , children = []
 
+  var childVNode;
   for (var i = 0; i < el.childNodes.length; i++) {
-    children.push(createVNode(el.childNodes[i]/*, i*/))
+    childVNode = createVNode(el.childNodes[i]/*, i*/);
+    if (childVNode) {
+      children.push(childVNode);
+    }
   }
 
   return new VNode(tagName, properties, children, null, namespace)


### PR DESCRIPTION
Comment nodes result in an error because they're not of node type 1 or 3, so createVNode doesn't handle them and returns nothing.  This change doesn't push those nodes onto the children array.