### PR TITLE
fromHTML(): Correcting an issue with whitespace nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ function createVNode(domNode, key) {
 createVNode.fromHTML = function(html, key) {
   var domNode = document.createElement('div'); // create container
   domNode.innerHTML = html; // browser parses HTML into DOM tree
-  return createVNode(domNode.children[0], key);
+  var child = domNode.children.length ? domNode.children[0] : domNode.firstChild;
+  return createVNode(child, key);
 };
 
 function createFromTextNode(tNode) {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function createVNode(domNode, key) {
 createVNode.fromHTML = function(html, key) {
   var domNode = document.createElement('div'); // create container
   domNode.innerHTML = html; // browser parses HTML into DOM tree
-  return createVNode(domNode.firstChild, key);
+  return createVNode(domNode.children[0], key);
 };
 
 function createFromTextNode(tNode) {


### PR DESCRIPTION
With the update to vdom-virtualize 0.0.11, fromHTML() changed its behavior due to the recent fix for #21. 
If a HTML string contains whitespace characters at the very beginning, it creates a VirtualText node instead. This might occur with certain template engines and configurations or when using HTML which wasn't generated by a machine.

This is due to the return value of Node.firstChild (which was introduced with the new version). It includes TextNodes which derive from any whitespace or control character in the provided HTML (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild#Notes)) or this example:

````js
var NL_HTML = '\n<div>Content</div>';
var node = document.createElement('div');
node.innerHTML = NL_HTML;

console.log('firstChild',node.firstChild); // Text
console.log('childNodes[0]',node.childNodes[0]); // Text
console.log('children[0]',node.children[0]); // Node
````

The old behavior of using Node.children should be restored for a better developing experience.